### PR TITLE
Restore viewport size

### DIFF
--- a/Screenshot/Screenshot.py
+++ b/Screenshot/Screenshot.py
@@ -72,6 +72,10 @@ class Screenshot:
         image_data = base64.b64decode(screenshot_data['data'])
         image = Image.open(BytesIO(image_data))
         image.save(output_path)
+        
+        # restore viewport size
+        self.driver.execute_cdp_cmd("Emulation.clearDeviceMetricsOverride", {})
+        time.sleep(0.5)  # wait render
 
         print(f"[✓] Full-page screenshot saved to: {output_path}")
 


### PR DESCRIPTION
### Describe the bug:
After capture the full page, viewport is incorrect. The scrollbar is lost.
### Solution:
Restore the viewport 
`self.driver.execute_cdp_cmd("Emulation.clearDeviceMetricsOverride", {})`