### PR TITLE
Use python 3.9 as default

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.8 x64 is removed. Use Python 3.9 as default